### PR TITLE
Automated smoke test for Ubuntu

### DIFF
--- a/.github/workflows/SmokeTest.yaml
+++ b/.github/workflows/SmokeTest.yaml
@@ -1,0 +1,39 @@
+name: Smoke Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  exec:
+    runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      # Provide required binaries
+      # fc-cache (fontconfig)
+      # gsettings (gnome)
+      - name: install
+        run: sudo apt-get update && sudo apt-get install -y ansible unzip fontconfig gnome-core snapd snap-confine
+
+      # Uninstall gh in order to avoid error: "A later version is already installed"
+      - name: Uninstall preconfigured github cli
+        run: sudo apt-get remove gh
+
+      - name: create vars.yaml
+        run: |
+          cat << EOF > vars.yml
+          mail: some@o.ne
+          displayName: Some one
+          gpgKey: "abcdef"
+          EOF
+
+      - name: smoke test
+        run: ./devbox -e ansible_become_pass=''

--- a/.github/workflows/SmokeTest.yaml
+++ b/.github/workflows/SmokeTest.yaml
@@ -35,5 +35,9 @@ jobs:
           gpgKey: "abcdef"
           EOF
 
-      - name: smoke test
+      - name: Initial smoke test
+        run: ./devbox -e ansible_become_pass=''
+
+      # Make sure the playbook also succeeds on incremental run
+      - name: Incremental smoke test
         run: ./devbox -e ansible_become_pass=''

--- a/devbox
+++ b/devbox
@@ -35,10 +35,13 @@ fi
 echo "starting ansible ..."
 echo "===================="
 
+# If you pass "-e ansible_become_pass=<your sudo password" it will not ask for the password.
+# This is discouraged and only for testing purposes
 ansible-playbook \
   -e ansible_python_interpreter="${PYTHON}" \
   --extra-vars="@${BASEDIR}/vars.yml" \
   "${BASEDIR}/playbook.yml" \
   --connection local \
   -i localhost, \
-  -K $@
+  $( [[ ! " $* " == *ansible_become_pass* ]] && echo '-K') \
+  $@

--- a/roles/cli-tools/tasks/aliases.yml
+++ b/roles/cli-tools/tasks/aliases.yml
@@ -2,10 +2,13 @@
   get_url:
     url: https://raw.githubusercontent.com/ahmetb/kubectl-alias/master/.kubectl_aliases
     dest: ~/.kubectl_aliases
-    mode: '0440'
+    # Require owner write to allow idempotent calls of ansible
+    mode: '0640'
+    force : yes
 
 - name: Download docker_aliases
   get_url:
     url: "https://github.com/schnatterer/docker-aliases/releases/download/{{ docker_aliases_version }}/default.docker-aliases"
     dest: ~/.docker_aliases
-    mode: '0440'
+    mode: '0640'
+    force : yes


### PR DESCRIPTION
 Add GitHub action that execs a simple smoke test.

Adding some basic validations using a proper infra testing tool would be a useful extension. For now, executing the playbook is better than nothing.