### PR TITLE
Add Dockerfile for testing/development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:focal-20210416
+
+# Install binaries needed by devboxes
+RUN apt-get update && \
+    apt-get install -y \
+      sudo \
+      ansible \ 
+      unzip \
+      fontconfig # fc-cache
+
+# Enable snap inside container 🙈
+# See https://github.com/ogra1/snapd-docker/blob/3a38d17a30d8295f6099b4e5769f54763e92ad4a/build.sh#L84
+RUN apt-get install -y fuse snapd snap-confine squashfuse init && \
+ apt-get clean && \
+ dpkg-divert --local --rename --add /sbin/udevadm && \
+ ln -s /bin/true /sbin/udevadm
+RUN systemctl enable snapd
+VOLUME ["/sys/fs/cgroup"]
+ENV container docker
+
+# Use a mock instead of installing Gnome (1,6GB) inside the container
+RUN echo 'echo gsettings mock' > /usr/bin/gsettings && chmod +x /usr/bin/gsettings  
+
+# This sets the password 'box'. 
+# Its a hashed value and was generated via "useradd dev" in an interactive shell and extracted from /etc/shadow
+RUN useradd -m -p '$6$dcac3osTmIrBAB7p$o6iwk3hirHgS3lQdS2yrFDMmeZRe5JS9vJlra6Cam.AVedpUMtJWFiQNoE2eePeuIM4yzz5cbkBtnutDxY.7D/' -s /bin/bash dev && \
+ usermod -aG sudo dev
+
+CMD [ "/sbin/init" ]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,34 @@ Install ansible `sudo pacman -S ansible`
 Just run the `devbox` script, on the first run it will ask some question to personalize the installed configurations.
 After that it will ask for your sudo password and then apply the ansible playbook. 
 
+You can also test the whole bunch in an ephemeral docker container.
+
+```shell
+docker build -t devboxes .
+docker run -v $(pwd):/home/dev/devboxes \
+    -it \
+    --tmpfs /run \
+    --tmpfs /run/lock \
+    --privileged \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+    -v /lib/modules:/lib/modules:ro \
+   --name devbox \
+    devboxes
+
+#login with: dev / box
+devboxes/devbox -e ansible_become_pass='box' 
+
+# Once ansible is done, explore the container as you like.
+# After you're done, you'll have to kill it from another terminal:
+docker rm -f devbox
+```
+
+Note that it's not a sandboxed container, because devboxes relies on snap, which relies on systemd, which both are not
+made for containers.
+In general, less privileges than `--privileged` flag would suffice (see [snpad-docker](https://github.com/ogra1/snapd-docker/blob/3a38d17a30d8295f6099b4e5769f54763e92ad4a/build.sh#L110-L113)).
+But, devboxes installs and runs docker (in this case in docker), which is what `--privileged` was made for, so its an obvious choice here.
+Use it only for testing and development!
+
 ## Tags
 
 Its also possible to only apply certain tags, e.g.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ devboxes/devbox -e ansible_become_pass='box'
 
 # Once ansible is done, explore the container as you like.
 # After you're done, you'll have to kill it from another terminal:
+docker stop devbox
+
+# If you need the container again later just
+docker start devbox
+#login with: dev / box
+docker attach devbox
+
+# If you want to get rid of it for good 
 docker rm -f devbox
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ docker attach devbox
 docker rm -f devbox
 ```
 
+Please be aware that the `devbox` scripts loads several GB worth of data from the internet and that as a result the 
+container will have take several GB on your harddrive (7GB at the time of writing).
+
 Note that it's not a sandboxed container, because devboxes relies on snap, which relies on systemd, which both are not
 made for containers.
 In general, less privileges than `--privileged` flag would suffice (see [snpad-docker](https://github.com/ogra1/snapd-docker/blob/3a38d17a30d8295f6099b4e5769f54763e92ad4a/build.sh#L110-L113)).


### PR DESCRIPTION
80% Dockerfile. Might be helpful for development and for lightweight playing around with the devboxes.

Has a lot more potential, though.
We could add an X-Server and GNOME in order to provide a devbox GUI from the container. In theory, this [is possible](https://github.com/mviereck/dockerfile-x11docker-gnome).
If that should work we could even provide pre built images of the devbox via an OCI registry.